### PR TITLE
resolve kernel warning

### DIFF
--- a/trunk/linux-4.4.x/net/bridge/br.c
+++ b/trunk/linux-4.4.x/net/bridge/br.c
@@ -227,9 +227,11 @@ static int __init br_init(void)
 	br_fdb_test_addr_hook = br_fdb_test_addr;
 #endif
 
+#if IS_MODULE(CONFIG_BRIDGE_NETFILTER)
 	pr_info("bridge: automatic filtering via arp/ip/ip6tables has been "
 		"deprecated. Update your scripts to load br_netfilter if you "
 		"need this.\n");
+#endif
 
 	return 0;
 

--- a/trunk/linux-4.4.x/net/netfilter/nf_conntrack_helper.c
+++ b/trunk/linux-4.4.x/net/netfilter/nf_conntrack_helper.c
@@ -464,7 +464,7 @@ static struct nf_ct_ext_type helper_extend __read_mostly = {
 
 int nf_conntrack_helper_pernet_init(struct net *net)
 {
-	net->ct.auto_assign_helper_warned = false;
+	net->ct.auto_assign_helper_warned = true;
 	net->ct.sysctl_auto_assign_helper = nf_ct_auto_assign_helper;
 	return nf_conntrack_helper_init_sysctl(net);
 }

--- a/trunk/user/scripts/mtd_storage.sh
+++ b/trunk/user/scripts/mtd_storage.sh
@@ -261,6 +261,7 @@ func_fill()
 #modprobe ip_set_bitmap_ip
 #modprobe ip_set_list_set
 #modprobe xt_set
+modprobe nf_conntrack_proto_gre
 
 #drop caches
 sync && echo 3 > /proc/sys/vm/drop_caches


### PR DESCRIPTION
* we still need netfilter conntrack helper , just disable `nf_conntrack: automatic helper assignment is deprecated and it will be removed soon. Use the iptables CT target to attach helpers instead.` warning.
* clarify bridge/netfilter message [original mail link](https://lists.linuxfoundation.org/pipermail/bridge/2016-October/010098.html)
* load nf_conntrack_proto_gre module to resolve `conntrack: generic helper won't handle protocol 47 Please consider loading the specific helper module.` warning.