### PR TITLE
fix UPnP port forwarding invalid

### DIFF
--- a/trunk/user/scripts/mtd_storage.sh
+++ b/trunk/user/scripts/mtd_storage.sh
@@ -322,6 +322,13 @@ EOF
 ### \$2 - WAN interface name (e.g. eth3 or ppp0)
 ### \$3 - WAN IPv4 address
 
+if [ $1 == "up" ] ; then
+	killall miniupnpd
+	if ! pgrep "miniupnpd" > /dev/null ; then
+		miniupnpd
+	fi
+fi
+
 EOF
 		chmod 755 "$script_postw"
 	fi


### PR DESCRIPTION
* fix UPnP port forwarding invalid.
* fix `miniupnpd: Cannot get IP address for ext interface [X]. Network is down`.